### PR TITLE
Add a third-party pygments lexer for better Julia syntax highlighting

### DIFF
--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -256,9 +256,9 @@ function save(name, p::Presentation, idx::Int)
 end
   
 
-const pygments = PyCall.PyNULL()
-const pygments_lexers = PyCall.PyNULL()
-const pygments_styles = PyCall.PyNULL()
+const PYGMENTS = PyCall.PyNULL()
+const PYGMENTS_LEXERS = PyCall.PyNULL()
+const PYGMENTS_STYLES = PyCall.PyNULL()
 const PYGMENTS_LEXERS_LANG_LIST = Symbol[]
 const RGX_EMOJI = r":([^\s]+):"
 const EMOJIS_MAP = Dict{String,String}()
@@ -316,10 +316,10 @@ function __init__()
     if !conda_exists("pygments-julia")
         PyCall.Conda.pip("install", "git+https://github.com/sisl/pygments-julia#egg=pygments_julia")
     end
-    copy!(pygments, PyCall.pyimport_conda("pygments", "pygments"))
-    copy!(pygments_lexers, PyCall.pyimport_conda("pygments.lexers", "pygments"))
-    copy!(pygments_styles, PyCall.pyimport_conda("pygments.styles", "pygments"))
-    all_lexer_langs = [ [lex[2]...] for lex in pygments_lexers.get_all_lexers() ]
+    copy!(PYGMENTS, PyCall.pyimport_conda("pygments", "pygments"))
+    copy!(PYGMENTS_LEXERS, PyCall.pyimport_conda("pygments.lexers", "pygments"))
+    copy!(PYGMENTS_STYLES, PyCall.pyimport_conda("pygments.styles", "pygments"))
+    all_lexer_langs = [ [lex[2]...] for lex in PYGMENTS_LEXERS.get_all_lexers() ]
     copy!(PYGMENTS_LEXERS_LANG_LIST, Symbol.(vcat(all_lexer_langs...)))
 
     # setup emoji list

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -259,6 +259,7 @@ end
 const pygments = PyCall.PyNULL()
 const pygments_lexers = PyCall.PyNULL()
 const pygments_styles = PyCall.PyNULL()
+const PYGMENTS_LEXERS_LANG_LIST = Symbol[]
 const RGX_EMOJI = r":([^\s]+):"
 const EMOJIS_MAP = Dict{String,String}()
 const EMOJIS_PNG_PATH = normpath(joinpath(@__DIR__, "..", "assets", "openmoji_png"))
@@ -307,7 +308,10 @@ end
 
 
 function __init__()
+
     GLMakie.activate!() # Just to make sure
+
+    # setup python
     # add a custom Julia lexer for Pygments
     if !conda_exists("pygments-julia")
         PyCall.Conda.pip("install", "git+https://github.com/sisl/pygments-julia#egg=pygments_julia")
@@ -315,6 +319,10 @@ function __init__()
     copy!(pygments, PyCall.pyimport_conda("pygments", "pygments"))
     copy!(pygments_lexers, PyCall.pyimport_conda("pygments.lexers", "pygments"))
     copy!(pygments_styles, PyCall.pyimport_conda("pygments.styles", "pygments"))
+    all_lexer_langs = [ [lex[2]...] for lex in pygments_lexers.get_all_lexers() ]
+    copy!(PYGMENTS_LEXERS_LANG_LIST, Symbol.(vcat(all_lexer_langs...)))
+
+    # setup emoji list
     emojis_map = JSON.parsefile(joinpath(@__DIR__, "..", "assets", "emojis.json"))
     # replace all _ in shorthands with -, because _ is parsed as emphasis in Markdown
     md_emojis_map = Dict( [ replace(sh, "_" => "-") => e for (sh, e) in pairs(emojis_map) ] )

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -24,8 +24,11 @@ import Makie.MakieLayout: @Block, inherit, round_to_IRect2D, initialize_block!
 
 
 # Resolve method ambiguity. Remove ASAP with next Makie update.
-Makie.MakieLayout.convert_for_attribute(t::Type{Makie.FreeTypeAbstraction.FTFont},
+# See also https://github.com/JuliaPlots/Makie.jl/issues/2247
+Makie.convert_for_attribute(t::Type{Makie.FreeTypeAbstraction.FTFont},
                             x::Makie.FreeTypeAbstraction.FTFont) = to_font(x)
+Makie.convert_for_attribute(t::Type{Union{RGBAf,Nothing}}, x) =
+    isnothing(x) ? nothing : Makie.convert_for_attribute(RGBAf, x)
 
 
 export Presentation, add_slide!, reset!, save

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -298,8 +298,20 @@ function load_emoji_image(shorthand)
 end
 
 
+# workaround for Conda.exists which is currenlty broken, see
+# https://github.com/JuliaPy/Conda.jl/pull/167
+function conda_exists(pkgname)
+    pkgs = PyCall.Conda._installed_packages()
+    pkgname ∈ pkgs
+end
+
+
 function __init__()
     GLMakie.activate!() # Just to make sure
+    # add a custom Julia lexer for Pygments
+    if !conda_exists("pygments-julia")
+        PyCall.Conda.pip("install", "git+https://github.com/sisl/pygments-julia#egg=pygments_julia")
+    end
     copy!(pygments, PyCall.pyimport_conda("pygments", "pygments"))
     copy!(pygments_lexers, PyCall.pyimport_conda("pygments.lexers", "pygments"))
     copy!(pygments_styles, PyCall.pyimport_conda("pygments.styles", "pygments"))

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -260,6 +260,7 @@ const PYGMENTS = PyCall.PyNULL()
 const PYGMENTS_LEXERS = PyCall.PyNULL()
 const PYGMENTS_STYLES = PyCall.PyNULL()
 const PYGMENTS_LEXERS_LANG_LIST = Symbol[]
+const PYGMENTS_STYLES_LIST = Symbol[]
 const RGX_EMOJI = r":([^\s]+):"
 const EMOJIS_MAP = Dict{String,String}()
 const EMOJIS_PNG_PATH = normpath(joinpath(@__DIR__, "..", "assets", "openmoji_png"))
@@ -321,6 +322,8 @@ function __init__()
     copy!(PYGMENTS_STYLES, PyCall.pyimport_conda("pygments.styles", "pygments"))
     all_lexer_langs = [ [lex[2]...] for lex in PYGMENTS_LEXERS.get_all_lexers() ]
     copy!(PYGMENTS_LEXERS_LANG_LIST, Symbol.(vcat(all_lexer_langs...)))
+    all_styles = collect(PYGMENTS_STYLES.get_all_styles())
+    copy!(PYGMENTS_STYLES_LIST, Symbol.(all_styles))
 
     # setup emoji list
     emojis_map = JSON.parsefile(joinpath(@__DIR__, "..", "assets", "emojis.json"))

--- a/src/formattedcode.jl
+++ b/src/formattedcode.jl
@@ -19,8 +19,8 @@ Plots syntax highlighted code.
         markerspace = :pixel,
         offset = (0.0, 0.0),
         inspectable = theme(scene, :inspectable),
-        pygstyler = pygments_styles.get_style_by_name("friendly"),
-        pyglexer = pygments_lexers.get_lexer_by_name("julia"),
+        pygstyler = PYGMENTS_STYLES.get_style_by_name("friendly"),
+        pyglexer = PYGMENTS_LEXERS.get_lexer_by_name("julia"),
         maxwidth = 0.0
     )
 end
@@ -32,7 +32,7 @@ function Makie.plot!(plot::FormattedCode{<:Tuple{<:Markdown.Code}})
         @warn "Language '$lang' not supported, using language julia."
         lang = :julia
     end
-    pyglexer = pygments_lexers.get_lexer_by_name(lang)
+    pyglexer = PYGMENTS_LEXERS.get_lexer_by_name(lang)
     attrs = plot.attributes
     attrs[:pyglexer] = pyglexer
     formattedcode!(plot, code; attrs...)

--- a/src/formattedcode.jl
+++ b/src/formattedcode.jl
@@ -28,9 +28,10 @@ end
 
 function Makie.plot!(plot::FormattedCode{<:Tuple{<:Markdown.Code}})
     code, lang = plot.code[].code, plot.code[].language
-    all_lexers = lowercase.(first.(collect(pygments_lexers.get_all_lexers())))
-    if !(lang in all_lexers)
-        @warn "Language '$lang' not supported, using julia."
+    all_lexer_langs = [ [lex[2]...] for lex in pygments_lexers.get_all_lexers() ]
+    all_lexer_langs = vcat(all_lexer_langs...)
+    if lang ∉ all_lexer_langs
+        @warn "Language '$lang' not supported, using language julia."
         lang = :julia
     end
     pyglexer = pygments_lexers.get_lexer_by_name(lang)

--- a/src/formattedcode.jl
+++ b/src/formattedcode.jl
@@ -28,9 +28,7 @@ end
 
 function Makie.plot!(plot::FormattedCode{<:Tuple{<:Markdown.Code}})
     code, lang = plot.code[].code, plot.code[].language
-    all_lexer_langs = [ [lex[2]...] for lex in pygments_lexers.get_all_lexers() ]
-    all_lexer_langs = vcat(all_lexer_langs...)
-    if lang ∉ all_lexer_langs
+    if Symbol(lang) ∉ PYGMENTS_LEXERS_SHORT_LIST
         @warn "Language '$lang' not supported, using language julia."
         lang = :julia
     end

--- a/src/formattedcode.jl
+++ b/src/formattedcode.jl
@@ -28,7 +28,7 @@ end
 
 function Makie.plot!(plot::FormattedCode{<:Tuple{<:Markdown.Code}})
     code, lang = plot.code[].code, plot.code[].language
-    if Symbol(lang) ∉ PYGMENTS_LEXERS_SHORT_LIST
+    if Symbol(lang) ∉ PYGMENTS_LEXERS_LANG_LIST
         @warn "Language '$lang' not supported, using language julia."
         lang = :julia
     end

--- a/src/formattedcodeblock.jl
+++ b/src/formattedcodeblock.jl
@@ -83,12 +83,13 @@ function initialize_block!(l::FormattedCodeblock)
         pygstyler = pygments_styles.get_style_by_name(string(style))
     end
 
-    all_lexers = lowercase.(first.(collect(pygments_lexers.get_all_lexers())))
+    all_lexer_langs = [ [lex[2]...] for lex in pygments_lexers.get_all_lexers() ]
+    all_lexer_langs = vcat(all_lexer_langs...)
     pyglexer = lift(l.language) do lang
-        if !(string(lang) in all_lexers)
+        if string(lang) ∉ all_lexer_langs
             @warn "Language '$lang' not supported, using language julia."
             lang = :julia
-            l.language[] = lang
+            l.language.val = lang
         end
         pyglexer = pygments_lexers.get_lexer_by_name(string(lang))
     end

--- a/src/formattedcodeblock.jl
+++ b/src/formattedcodeblock.jl
@@ -84,7 +84,7 @@ function initialize_block!(l::FormattedCodeblock)
     end
 
     pyglexer = lift(l.language) do lang
-        if lang ∉ PYGMENTS_LEXERS_SHORT_LIST
+        if lang ∉ PYGMENTS_LEXERS_LANG_LIST
             @warn "Language '$lang' not supported, using language julia."
             lang = :julia
             l.language.val = lang

--- a/src/formattedcodeblock.jl
+++ b/src/formattedcodeblock.jl
@@ -73,9 +73,8 @@ function initialize_block!(l::FormattedCodeblock)
     textbb = Ref(BBox(0, 1, 0, 1))
     maxwidth = Observable(0.0)
 
-    all_styles = Symbol.(collect(PYGMENTS_STYLES.get_all_styles()))
     pygstyler = lift(l.codestyle) do style
-        if !(style in all_styles)
+        if style ∉ PYGMENTS_STYLES_LIST
             @warn "Could not find style '$style', using style friendly."
             style = :friendly
             l.codestyle[] = style

--- a/src/formattedcodeblock.jl
+++ b/src/formattedcodeblock.jl
@@ -83,10 +83,8 @@ function initialize_block!(l::FormattedCodeblock)
         pygstyler = pygments_styles.get_style_by_name(string(style))
     end
 
-    all_lexer_langs = [ [lex[2]...] for lex in pygments_lexers.get_all_lexers() ]
-    all_lexer_langs = vcat(all_lexer_langs...)
     pyglexer = lift(l.language) do lang
-        if string(lang) ∉ all_lexer_langs
+        if lang ∉ PYGMENTS_LEXERS_SHORT_LIST
             @warn "Language '$lang' not supported, using language julia."
             lang = :julia
             l.language.val = lang

--- a/src/formattedcodeblock.jl
+++ b/src/formattedcodeblock.jl
@@ -73,14 +73,14 @@ function initialize_block!(l::FormattedCodeblock)
     textbb = Ref(BBox(0, 1, 0, 1))
     maxwidth = Observable(0.0)
 
-    all_styles = Symbol.(collect(pygments_styles.get_all_styles()))
+    all_styles = Symbol.(collect(PYGMENTS_STYLES.get_all_styles()))
     pygstyler = lift(l.codestyle) do style
         if !(style in all_styles)
             @warn "Could not find style '$style', using style friendly."
             style = :friendly
             l.codestyle[] = style
         end
-        pygstyler = pygments_styles.get_style_by_name(string(style))
+        pygstyler = PYGMENTS_STYLES.get_style_by_name(string(style))
     end
 
     pyglexer = lift(l.language) do lang
@@ -89,7 +89,7 @@ function initialize_block!(l::FormattedCodeblock)
             lang = :julia
             l.language.val = lang
         end
-        pyglexer = pygments_lexers.get_lexer_by_name(string(lang))
+        pyglexer = PYGMENTS_LEXERS.get_lexer_by_name(string(lang))
     end
 
     backgroundcolor = lift(pygstyler, l.backgroundcolor) do styler, bg

--- a/src/markdownbox.jl
+++ b/src/markdownbox.jl
@@ -46,10 +46,10 @@
         backgroundvisible::Bool = false
         "The color of the background. "
         backgroundcolor::RGBAf = RGBf(0.9, 0.9, 0.9)
+        "The color of the background of a code snippet. Set to `nothing` to use background color from syntax highlighter."
+        code_backgroundcolor::Union{RGBAf,Nothing} = nothing
         "The syntax highlighting theme."
         codestyle::Symbol = :material
-        "The code language."
-        language::Symbol = :julia
         "The @printf pattern to format enumeration items"
         enumeration_pattern = "%i)"
         "The symbol for itemization items"
@@ -57,6 +57,13 @@
         "The horizontal divider's lineheight multiplier for the text."
         divider_color::RGBAf = :lightgray
     end
+end
+
+
+# Override type conversion for @Block attributes,
+# see https://github.com/JuliaPlots/Makie.jl/issues/2247
+function Makie.convert_for_attribute(t::Type{Union{RGBAf,Nothing}}, x)
+    return isnothing(x) ? nothing : Makie.convert_for_attribute(RGBAf, x)
 end
 
 
@@ -130,9 +137,9 @@ function render_element(md::Markdown.Code, scene, l::MarkdownBox)
                    width = l.width, height = l.height,
                    alignmode = l.alignmode,
                    backgroundvisible = true,
-                   backgroundcolor = l.backgroundcolor,
+                   backgroundcolor = l.code_backgroundcolor,
                    codestyle = l.codestyle,
-                   language = l.language)
+                   language = Symbol(md.language))
 end
 
 

--- a/src/markdownbox.jl
+++ b/src/markdownbox.jl
@@ -60,13 +60,6 @@
 end
 
 
-# Override type conversion for @Block attributes,
-# see https://github.com/JuliaPlots/Makie.jl/issues/2247
-function Makie.convert_for_attribute(t::Type{Union{RGBAf,Nothing}}, x)
-    return isnothing(x) ? nothing : Makie.convert_for_attribute(RGBAf, x)
-end
-
-
 MarkdownBox(x, md::AbstractString; kwargs...) = MarkdownBox(x, md = Markdown.parse(text); kwargs...)
 MarkdownBox(x, md::Markdown.MD; kwargs...) = MarkdownBox(x, md = md; kwargs...)
 


### PR DESCRIPTION
Closes #29 

Also refactor a few things like
- make const globals all upper case
- make list of available `pygments` lexers and stylers global constant

Also need to introduce a separate `code_backgroundcolor` keyword for `MarkdownBox` and revert `backgroundcolor::Union{RGBAf,Nothing}` back to `RGBAf`. Reason is that using `backgroundcolor = :green` currently changes the color of all Markdown elements, but we want to treat the background of code blocks separately.

This is not yet ready for merging, because of a problem with implicit attribute conversion, cf. https://github.com/JuliaPlots/Makie.jl/issues/2247