### PR TITLE
Introduce slide elements

### DIFF
--- a/examples/mwe2.jl
+++ b/examples/mwe2.jl
@@ -1,0 +1,51 @@
+using GLMakie, MakieSlides, Colors
+GLMakie.activate!()
+
+# define some colors and configure our Makie theme
+fontblue=colorant"#2325C0"
+blue=colorant"#0000a3"
+yellow=colorant"#ffe200"
+set_theme!(Theme(Box=Theme(strokevisible=false)))
+
+
+# create a presentation
+p = Presentation(figure_padding=0)
+
+### setup a slide master for our presentation
+### whenever we add a slide and draw on it then elements from the slidemaster are added,
+### unless we override them locally
+
+new_slidemaster!(p)
+add_to_slide!(p, element=:footer) do fig
+  # footer with page number
+  i = MakieSlides.current_index(p)
+  n = length(p)
+  Box(fig[1,1], color=blue, strokevisible=false)
+  Box(fig[1,2], color=yellow, strokevisible=false)
+  Label(fig[1,3], "$i/$n", textsize=30, tellheight=false)
+  colgap!(fig.layout, 0)
+end
+
+### populate slides
+
+new_slide!(p)
+add_to_slide!(p) do fig
+  FormattedLabel(fig[1,1], "MWE with MakieSlides",
+                 textsize=80, halign=:center)
+end
+
+
+new_slide!(p)
+add_to_slide!(p, element=:header) do fig
+  Box(fig[1,1], color=blue)
+  Box(fig[1,2], color=yellow)
+  colgap!(fig.layout, 0)
+end
+add_to_slide!(p) do fig
+  FormattedLabel(fig[1,1], "A very long heading that should suffer from a line break at some point", textsize=40,
+                 valign=:top, backgroundcolor=yellow, backgroundvisible=true,
+                 strokevisible=false, color=fontblue)
+  Box(fig[2,1], tellheight=true, visible=false)
+end
+
+p

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -350,17 +350,17 @@ figure will be reset before drawing.
 function add_to_slide!(f::Function, p::Presentation; element::Symbol = :body, clear = true)
     # This is set up to render each slide immediately to get compilation times 
     # out of the way and perhaps catch errors a bit earlier
+    activate_element!(p, element)
+    fig = p.elements[element].fig
     try
         # with_updates_suspended should stop layouting to trigger when the slide
         # gets set up. This should speed up slide creation a bit.
-        activate_element!(p, element)
-        fig = p.elements[element].fig
         with_updates_suspended(() -> f(fig), fig.layout)
-        p.slides[p.idx][element] = f
     catch e
         @error "Failed to add slide - maybe the function signature does not match f(::Presentation)?"
         rethrow(e)
     end
+    p.slides[p.idx][element] = f
     return
 end
 

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -201,6 +201,32 @@ function Presentation(; kwargs...)
 end
 
 
+function deactivate_element!(p::Presentation, name::Symbol)
+    name ∉ keys(p.elements) && error("unknown slide element '$name'")
+    el = p.elements[name]
+    # remove scene
+    s_idx = findfirst(s -> s === el.fig.scene, p.parent.scene.children)
+    !isnothing(s_idx) && deleteat!(p.parent.scene.children, s_idx)
+    # remove layout
+    l_idx = findfirst(l -> l === el.fig.layout, p.parent.layout.content)
+    !isnothing(l_idx) && deleteat!(p.parent.layout.content, l_idx)
+    return
+end
+
+
+function activate_element!(p::Presentation, name::Symbol)
+    name ∉ keys(p.elements) && error("unknown slide element '$name'")
+    el = p.elements[name]
+    # insert scene, but only if not already present
+    s_idx = findfirst(s -> s === el.fig.scene, p.parent.scene.children)
+    isnothing(s_idx) && push!(p.parent.scene.children, el.fig.scene)
+    # insert layout, but only if not already present
+    l_idx = findfirst(l -> l === el.fig.layout, p.parent.layout.content)
+    isnothing(l_idx) && (p.parent.layout[el.span...] = el.fig.layout)
+    return
+end
+
+
 function _set_slide_idx!(p::Presentation, i)
     # Moving through slides quickly seems to sometimes trigger plot insertion 
     # before or during the `empty!(fig)` procedure. This causes emptying to

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -16,7 +16,7 @@ import Cairo
 
 
 # Makie internal dependencies of formattedtext.jl, formattedcode.jl
-import Makie: NativeFont, gl_bboxes, attribute_per_char, glyph_collection, RGBAf
+import Makie: NativeFont, gl_bboxes, attribute_per_char, glyph_collection, RGBAf, GridLayoutBase
 import MakieCore: automatic
 # Makie internal dependencies of formattedlabel.jl, formattedlist, markdownbox.jl
 using Makie.MakieLayout
@@ -176,7 +176,7 @@ function Presentation(; kwargs...)
     on(alignmode) do al
         for (_, el) in elements
             el.fig.layout.alignmode[] = al
-            Makie.GridLayoutBase.update!(el.fig.layout)
+            GridLayoutBase.update!(el.fig.layout)
         end
     end
     notify(alignmode)

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -228,7 +228,7 @@ Base.length(p::Presentation) = length(p.slide_elements)
 Base.eachindex(p::Presentation) = 1:length(p.slide_elements)
 next_slide!(p::Presentation) = set_slide_idx!(p, p.idx + 1)
 previous_slide!(p::Presentation) = set_slide_idx!(p, p.idx - 1)
-reset!(p::Presentation) = _set_slide_idx!(p, 1)
+reset!(p::Presentation) = set_slide_idx!(p, 1)
 current_index(p::Presentation) = p.idx
 
 

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -60,6 +60,7 @@ mutable struct SlideElement
     parent::Figure
     fig::Figure
     span::NTuple{2,Union{Int64,UnitRange{Int64}}}
+    active::Bool
 end
 
 
@@ -69,7 +70,7 @@ function SlideElement(parent::Figure, element_scene::Scene, span;
     parent.layout[span...] = layout
     fig = Figure(element_scene, layout, [], Attributes(), Ref{Any}(nothing))
     layout.parent = fig
-    return SlideElement(parent, fig, span)
+    return SlideElement(parent, fig, span, true)
 end
 
 

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -173,10 +173,10 @@ function _set_slide_idx!(p::Presentation, i)
     if !p.locked && i != p.idx && (1 <= i <= length(p.slides))
         p.locked = true
         p.idx = i
-        for fig in p.figures
+        for (name, fig) in p.figures
             p.clear[p.idx] && empty!(fig)
+            name === :body && p.slides[p.idx](fig)
         end
-        p.slides[p.idx](f)
         p.locked = false
     end
     return
@@ -225,11 +225,11 @@ function add_slide!(f::Function, p::Presentation, clear = true)
     # This is set up to render each slide immediately to get compilation times 
     # out of the way and perhaps catch errors a bit earlier
     try
-        for fig in p.figures
+        for (name, fig) in p.figures
             clear && empty!(fig)
             # with_updates_suspended should stop layouting to trigger when the slide
             # gets set up. This should speed up slide creation a bit.
-            with_updates_suspended(() -> f(fig), fig.layout)
+            name === :body && with_updates_suspended(() -> f(fig), fig.layout)
         end
         push!(p.slides, f)
         push!(p.clear, p.idx == 1 || clear) # always clear first slide

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -60,7 +60,6 @@ mutable struct SlideElement
     parent::Figure
     fig::Figure
     span::NTuple{2,Union{Int64,UnitRange{Int64}}}
-    enabled::Bool
 end
 
 
@@ -70,7 +69,7 @@ function SlideElement(parent::Figure, element_scene::Scene, span;
     parent.layout[span...] = layout
     fig = Figure(element_scene, layout, [], Attributes(), Ref{Any}(nothing))
     layout.parent = fig
-    return SlideElement(parent, fig, span, true)
+    return SlideElement(parent, fig, span)
 end
 
 

--- a/src/MakieSlides.jl
+++ b/src/MakieSlides.jl
@@ -103,27 +103,37 @@ end
 """
     Presentation(; kwargs...)
 
-Creates a `pres::Presentation` with a background figure `parent`
-and a set of content figures `figures`.
+Creates a `pres::Presentation` with a background figure `parent::Figure`
+and a set of `element::SlideElement` for slide content.
+that allow to partition the slide for content placement.
 The former remains static during the presentation and acts as the background and 
-window. The latter act as thes slide and they get cleared and reassambled every
-time a new slide is requested. (This includes events.)
+window. The latter act as partioning of a slide into which content can be added.
+They can get cleared and reassambled every time a new slide is requested.
+(This includes events.)
 
 To add a slide use:
 
-    add_to_slide!(pres[, clear = true]) do fig
-        # Plot your slide to fig
+    new_slide!(pres)
+    add_to_slide!(pres[, element = :body, clear = true]) do fig
+        # Plot your content to fig
     end
 
-Note that `add_to_slide!` immediately switches to and draws the newly added slide.
-This is done to get rid of compilation times beforehand.
+Note that `new_slide!` inserts a new slides, whereas `add_to_slide!` adds content to the
+currently active (or previously created) slide. The added content is drawn immediately,
+this is done to get rid of compilation times beforehand.
+
+Available slide elements:
+- `:body`: the main place to put content, its the default element for `add_to_slide!`
+- `:header`: space above `:body` to put dates, section titles, etc.
+- `:footer`: space below `:body`, to put dates, section titles, etc.
+- `:sidebar_lhs`: space left to `:body`, could be used for a quick overview
+- `:sidebar_rhs`: space right to `:body`, could be used for a quick overview
 
 To switch to a different slide:
 - `next_slide!(pres)`: Advance to the next slide. Default keys: Keyboard.right, Keyboard.enter
 - `previous_slide!(pres)`: Go to the previous slide. Default keys: Keyboard.left
 - `reset!(pres)`: Go to the first slide. Defaults keys: Keyboard.home
 - `set_slide_idx!(pres, idx)`: Go a specified slide.
-
 """
 function Presentation(; kwargs...)
     # This is a modified version of the Figure() constructor.


### PR DESCRIPTION
Add basic features needed to complete #13 

This version here basically splits the current foreground figure `figure` of `Presentation` into multiple elements, `header, footer, body, sidebar_lhs, sidebar_rhs`. 
I choose this over putting `header, footer, sidebar_lhs, sidebar_rhs` into the background figure `parent` in `Presentation`, because I anticipate that we also need to redraw those frequently, e.g. when we add slide number support.

You can now create slides with
```julia
new_slide!(pres)
add_to_slide!(pres, element=:header) do fig
   # ...
end
```
Note that I replaced `add_slide!` with new `new_slide!` and `add_to_slide!`.

For now the elements are created for all elements. I can imagine that we later start every `new_slide!` with no elements present and then allow to add a header or footer element dynamically and on a slide by slide basis.